### PR TITLE
Implement write to file

### DIFF
--- a/assembler.c
+++ b/assembler.c
@@ -64,7 +64,7 @@ void itob(uint16_t num, char *b, int len)
 //              symbols:        pointer to linked list that handles symbol lookups
 //              default_val:    default value to insert into `symbols` list on insertion
 // Returns:     void
-void build_A_COMMAND(char *line_in, char *line_out, LinkedList *symbols, int default_val)
+void build_A_COMMAND(char *line_in, char *line_out, LinkedList *symbols, int *default_val)
 {
     uint16_t i;
 
@@ -75,7 +75,9 @@ void build_A_COMMAND(char *line_in, char *line_out, LinkedList *symbols, int def
         itob(i, line_out, 16);  // convert i to 15+1-bit string and save to output
     } else {                                      
         // treat `line_in` as symbol
-        i = search(symbols, line_in + 1, default_val);
+        i = search(symbols, line_in + 1, *default_val);
+        if (i == *default_val)
+            (*default_val)++;
         itob(i, line_out, 16);
     }
 }
@@ -327,7 +329,7 @@ int main(int argc, char **argv)
 
             switch (get_command_type(line_in)) {
                 case A_COMMAND:
-                    build_A_COMMAND(line_in, line_out, symbols, default_val++); 
+                    build_A_COMMAND(line_in, line_out, symbols, &default_val); 
                     printf("%s\n", line_out);
                     fprintf(fp_out, "%s\n", line_out);
                     break;


### PR DESCRIPTION
Revise assembler.c so that output is written to file in addition to stdout. Output path is identical to input path as received from argv, except extension is changed from `.asm` -> `.hack`. Confirmed that output .hack files match expected .hack files for tests Add.asm, Max.asm, MaxL.asm, Rect.asm, RectL.asm, Pong.asm, and PongL.asm.

Corrected bug to ensure that `default_val` passed to linked list `search()` function via `build_A_COMMAND()` only increments when that default val is used (i.e., the symbol is not found). If the symbol is found (and thus `default_val != search(...)`), then `default_val` is not incremented.